### PR TITLE
[Feat] 공통컴포넌트 - 배지 제작

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -6,12 +6,12 @@ interface BadgeProps {
 
 const Badge = ({ className = '', variant = 'default', label }: BadgeProps) => {
   const variantStyles = {
-    default: 'bg-gray-200 text-gray-800',
-    primary: 'bg-blue-200 text-blue-800',
-    success: 'bg-green-200 text-green-800',
-    warning: 'bg-yellow-200 text-yellow-800',
-    danger: 'bg-red-200 text-red-800',
-    info: 'bg-purple-200 text-purple-800',
+    default: 'bg-[#f3f4f6 ]text-[#1F2937]',
+    primary: 'bg-[#DBEAFE] text-[#1E40AF]]',
+    success: 'bg-[#DCFCE7]] text-[#166534]',
+    warning: 'bg-[#FEF9C3] text-[#854D0E]',
+    danger: 'bg-[#FEE2E2] text-[#991B1B]',
+    info: 'bg-[#F3E8FF] text-[#6B21A8]',
   }
 
   return (
@@ -27,19 +27,13 @@ const Badge = ({ className = '', variant = 'default', label }: BadgeProps) => {
 // 사용 테스트
 const BadgeTest = () => {
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
-      <div className="mx-auto max-w-4xl">
-        <h1 className="mb-8 text-2xl font-bold">Badge Component Demo</h1>
-
-        <div className="mb-12 flex flex-wrap gap-4">
-          <Badge variant="default" label="Default" />
-          <Badge variant="primary" label="Primary" />
-          <Badge variant="success" label="Success" />
-          <Badge variant="warning" label="Warning" />
-          <Badge variant="danger" label="Danger" />
-          <Badge variant="info" label="Info" />
-        </div>
-      </div>
+    <div className="mb-12 flex flex-wrap gap-4">
+      <Badge variant="default" label="Default" />
+      <Badge variant="primary" label="Primary" />
+      <Badge variant="success" label="Success" />
+      <Badge variant="warning" label="Warning" />
+      <Badge variant="danger" label="Danger" />
+      <Badge variant="info" label="Info" />
     </div>
   )
 }

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,48 @@
+interface BadgeProps {
+  className?: string
+  variant?: 'default' | 'primary' | 'success' | 'warning' | 'danger' | 'info'
+  label: string
+}
+
+const Badge = ({ className = '', variant = 'default', label }: BadgeProps) => {
+  const variantStyles = {
+    default: 'bg-gray-200 text-gray-800',
+    primary: 'bg-blue-200 text-blue-800',
+    success: 'bg-green-200 text-green-800',
+    warning: 'bg-yellow-200 text-yellow-800',
+    danger: 'bg-red-200 text-red-800',
+    info: 'bg-purple-200 text-purple-800',
+  }
+
+  return (
+    <button
+      className={`rounded-full px-6 py-3 text-lg font-semibold ${variantStyles[variant]} ${className} `}
+      type="button"
+    >
+      {label}
+    </button>
+  )
+}
+
+// 사용 테스트
+const BadgeTest = () => {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-8 text-2xl font-bold">Badge Component Demo</h1>
+
+        <div className="mb-12 flex flex-wrap gap-4">
+          <Badge variant="default" label="Default" />
+          <Badge variant="primary" label="Primary" />
+          <Badge variant="success" label="Success" />
+          <Badge variant="warning" label="Warning" />
+          <Badge variant="danger" label="Danger" />
+          <Badge variant="info" label="Info" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BadgeTest
+export { Badge }

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -4,19 +4,24 @@ interface BadgeProps {
   label: string
 }
 
-const Badge = ({ className = '', variant = 'default', label }: BadgeProps) => {
+export const Badge = ({
+  className = '',
+  variant = 'default',
+  label,
+}: BadgeProps) => {
   const variantStyles = {
-    default: 'bg-[#f3f4f6 ]text-[#1F2937]',
-    primary: 'bg-[#DBEAFE] text-[#1E40AF]]',
-    success: 'bg-[#DCFCE7]] text-[#166534]',
+    default: 'bg-[#f3f4f6] text-[#1F2937]',
+    primary: 'bg-[#DBEAFE] text-[#1E40AF]',
+    success: 'bg-[#DCFCE7] text-[#166534]',
     warning: 'bg-[#FEF9C3] text-[#854D0E]',
     danger: 'bg-[#FEE2E2] text-[#991B1B]',
     info: 'bg-[#F3E8FF] text-[#6B21A8]',
   }
 
+  //cursor-default:클릭 비활성화 / px-2 (8px) py-1(4px) text-xs(12px)
   return (
     <button
-      className={`rounded-full px-6 py-3 text-lg font-semibold ${variantStyles[variant]} ${className} `}
+      className={`cursor-default rounded-full px-2 py-1 text-xs font-medium ${variantStyles[variant]} ${className} `}
       type="button"
     >
       {label}
@@ -25,18 +30,15 @@ const Badge = ({ className = '', variant = 'default', label }: BadgeProps) => {
 }
 
 // 사용 테스트
-const BadgeTest = () => {
-  return (
-    <div className="mb-12 flex flex-wrap gap-4">
-      <Badge variant="default" label="Default" />
-      <Badge variant="primary" label="Primary" />
-      <Badge variant="success" label="Success" />
-      <Badge variant="warning" label="Warning" />
-      <Badge variant="danger" label="Danger" />
-      <Badge variant="info" label="Info" />
-    </div>
-  )
-}
-
-export default BadgeTest
-export { Badge }
+// export const BadgeTest = () => {
+//   return (
+//     <div className="mb-12 flex flex-wrap gap-4">
+//       <Badge variant="default" label="Default" />
+//       <Badge variant="primary" label="Primary" />
+//       <Badge variant="success" label="Success" />
+//       <Badge variant="warning" label="Warning" />
+//       <Badge variant="danger" label="Danger" />
+//       <Badge variant="info" label="Info" />
+//     </div>
+//   )
+// }


### PR DESCRIPTION
## PR 제목

- [Feat] 공통컴포넌트 - 배지 제작

---

## 작업 내용

- 기본 / 중요 / 성공 / 경고 / 위험 / 정보 등으로 variant를 만들어서 공통 컴포넌트로 제작
- 다른 페이지에서 동일한 UI로 보여질 수 있게 Props를 넣어서 제작 

---

## 체크리스트
- [x] 코드에 불필요한 console.log 제거
- [x] 로컬에서 정상 동작 확인
- [x] 테스트 코드 통과
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈

Closes #6 

---

## 스크린샷 (선택)
 
<img width="447" height="31" alt="스크린샷 2025-10-16 오전 2 34 15" src="https://github.com/user-attachments/assets/856f7484-6a77-4adb-90a1-11b91e6b96cb" />
