### PR TITLE
[Feat] 사이드 바 공통 컴포넌트 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router";
 import Sidebar from "./components/sidebar";
 import "./App.css";
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,16 @@
-import './App.css'
+import { BrowserRouter as Router } from "react-router-dom";
+import Sidebar from "./components/sidebar";
+import "./App.css";
 
 function App() {
-  return <div>template</div>
+  return (
+    <Router>
+      <div className="flex min-h-screen">
+        {/* 사이드바 */}
+        <Sidebar />
+      </div>
+    </Router>
+  );
 }
 
-export default App
+export default App;

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import {
+  Users,
+  UserX,
+  BookOpen,
+  ClipboardList,
+  Star,
+  Megaphone,
+  ChevronDown,
+} from "lucide-react";
+
+const Sidebar = () => {
+  return (
+    <aside className="w-64 min-h-screen bg-white border-r border-gray-200 flex flex-col p-4">
+      {/* 상단 제목 */}
+      <h2 className="text-gray-900 font-bold text-lg mb-6">관리자 패널</h2>
+
+      {/* 메뉴 섹션 */}
+      <nav className="flex flex-col gap-6 text-[15px] text-gray-700 font-medium">
+        {/* 회원 관리 */}
+        <div>
+          <div className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2">
+            <span>회원 관리</span>
+          </div>
+          <ul className="flex flex-col gap-1">
+            <SidebarLink to="/user-management" icon={<Users size={18} />} label="유저 관리" />
+            <SidebarLink to="/withdraw-management" icon={<UserX size={18} />} label="탈퇴 관리" />
+          </ul>
+        </div>
+
+        {/* 스터디 관리 */}
+        <div>
+          <div className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2">
+            <span>스터디 관리</span>
+            <ChevronDown size={16} className="text-gray-400" />
+          </div>
+          <ul className="flex flex-col gap-1">
+            <SidebarLink to="/lecture-management" icon={<BookOpen size={18} />} label="강의 관리" />
+            <SidebarLink to="/study-group-management" icon={<ClipboardList size={18} />} label="스터디 그룹 관리" />
+            <SidebarLink to="/review-management" icon={<Star size={18} />} label="리뷰 관리" />
+          </ul>
+        </div>
+
+        {/* 스터디 구인 공고 관리 */}
+        <div>
+          <div className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2">
+            <span>스터디 구인 공고 관리</span>
+          </div>
+          <ul className="flex flex-col gap-1">
+            <SidebarLink to="/post-management" icon={<Megaphone size={18} />} label="공고 관리" />
+            <SidebarLink to="/support-management" icon={<ClipboardList size={18} />} label="지원 내역 관리" />
+          </ul>
+        </div>
+      </nav>
+    </aside>
+  );
+};
+
+// 🔗 NavLink 스타일 구성
+interface SidebarLinkProps {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+}
+
+const SidebarLink = ({ to, icon, label }: SidebarLinkProps) => {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `flex items-center gap-2 px-3 py-2 rounded-md transition-colors duration-150 ${
+          isActive
+            ? "bg-yellow-100 text-yellow-700 font-semibold"
+            : "text-gray-700 hover:bg-gray-100"
+        }`
+      }
+    >
+      <span className="text-gray-500">{icon}</span>
+      <span>{label}</span>
+    </NavLink>
+  );
+};
+
+export default Sidebar;

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -10,11 +10,81 @@ import {
   ChevronDown,
 } from "lucide-react";
 
+// 메뉴 데이터 타입 정의
+interface MenuItem {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+}
+
+interface MenuSection {
+  title: string;
+  items: MenuItem[];
+}
+
+// 📦 메뉴 리스트 컴포넌트 (각 섹션 안에서 사용)
+const SidebarLinks = ({ items }: { items: MenuItem[] }) => {
+  return (
+    <ul className="flex flex-col gap-1">
+      {items.map(({ to, icon, label }) => (
+        <li key={to}>
+          <NavLink
+            to={to}
+            className={({ isActive }) =>
+              `flex items-center gap-2 px-3 py-2 rounded-md transition-colors duration-150 ${
+                isActive
+                  ? "bg-yellow-100 text-yellow-700 font-semibold"
+                  : "text-gray-700 hover:bg-gray-100"
+              }`
+            }
+          >
+            <span className="text-gray-500">{icon}</span>
+            <span>{label}</span>
+          </NavLink>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
 const Sidebar = () => {
-  // 각 섹션 열림 상태 관리
-  const [isUserOpen, setIsUserOpen] = useState(true);
-  const [isStudyOpen, setIsStudyOpen] = useState(true);
-  const [isPostOpen, setIsPostOpen] = useState(true);
+  // 각 섹션 열림 상태
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>({
+    user: true,
+    study: true,
+    post: true,
+  });
+
+  // 섹션 토글 핸들러
+  const toggleSection = (key: string) => {
+    setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  // 📚 메뉴 구성 데이터 (여기만 수정하면 메뉴 추가 가능)
+  const menuSections: Record<string, MenuSection> = {
+    user: {
+      title: "회원 관리",
+      items: [
+        { to: "/user-management", icon: <Users size={18} />, label: "유저 관리" },
+        { to: "/withdraw-management", icon: <UserX size={18} />, label: "탈퇴 관리" },
+      ],
+    },
+    study: {
+      title: "스터디 관리",
+      items: [
+        { to: "/lecture-management", icon: <BookOpen size={18} />, label: "강의 관리" },
+        { to: "/study-group-management", icon: <ClipboardList size={18} />, label: "스터디 그룹 관리" },
+        { to: "/review-management", icon: <Star size={18} />, label: "리뷰 관리" },
+      ],
+    },
+    post: {
+      title: "스터디 구인 공고 관리",
+      items: [
+        { to: "/post-management", icon: <Megaphone size={18} />, label: "공고 관리" },
+        { to: "/support-management", icon: <ClipboardList size={18} />, label: "지원 내역 관리" },
+      ],
+    },
+  };
 
   return (
     <aside className="w-64 min-h-screen bg-white border-r border-gray-200 flex flex-col p-4">
@@ -23,100 +93,29 @@ const Sidebar = () => {
 
       {/* 메뉴 섹션 */}
       <nav className="flex flex-col gap-6 text-[15px] text-gray-700 font-medium">
-        
-        {/* 회원 관리 */}
-        <div>
-          <div
-            className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer"
-            onClick={() => setIsUserOpen(!isUserOpen)}
-          >
-            <span>회원 관리</span>
-            <ChevronDown
-              size={16}
-              className={`text-gray-400 transition-transform duration-200 ${
-                isUserOpen ? "rotate-0" : "-rotate-90"
-              }`}
-            />
-          </div>
-          {isUserOpen && (
-            <ul className="flex flex-col gap-1">
-              <SidebarLink to="/user-management" icon={<Users size={18} />} label="유저 관리" />
-              <SidebarLink to="/withdraw-management" icon={<UserX size={18} />} label="탈퇴 관리" />
-            </ul>
-          )}
-        </div>
+        {Object.entries(menuSections).map(([key, section]) => (
+          <div key={key}>
+            
+            {/* 섹션 헤더 */}
+            <div
+              className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer select-none"
+              onClick={() => toggleSection(key)}
+            >
+              <span>{section.title}</span>
+              <ChevronDown
+                size={16}
+                className={`text-gray-400 transition-transform duration-200 ${
+                  openSections[key] ? "rotate-0" : "-rotate-90"
+                }`}
+              />
+            </div>
 
-        {/* 스터디 관리 */}
-        <div>
-          <div
-            className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer"
-            onClick={() => setIsStudyOpen(!isStudyOpen)}
-          >
-            <span>스터디 관리</span>
-            <ChevronDown
-              size={16}
-              className={`text-gray-400 transition-transform duration-200 ${
-                isStudyOpen ? "rotate-0" : "-rotate-90"
-              }`}
-            />
+            {/* 섹션 내부 메뉴 */}
+            {openSections[key] && <SidebarLinks items={section.items} />}
           </div>
-          {isStudyOpen && (
-            <ul className="flex flex-col gap-1">
-              <SidebarLink to="/lecture-management" icon={<BookOpen size={18} />} label="강의 관리" />
-              <SidebarLink to="/study-group-management" icon={<ClipboardList size={18} />} label="스터디 그룹 관리" />
-              <SidebarLink to="/review-management" icon={<Star size={18} />} label="리뷰 관리" />
-            </ul>
-          )}
-        </div>
-
-        {/* 스터디 구인 공고 관리 */}
-        <div>
-          <div
-            className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer"
-            onClick={() => setIsPostOpen(!isPostOpen)}
-          >
-            <span>스터디 구인 공고 관리</span>
-            <ChevronDown
-              size={16}
-              className={`text-gray-400 transition-transform duration-200 ${
-                isPostOpen ? "rotate-0" : "-rotate-90"
-              }`}
-            />
-          </div>
-          {isPostOpen && (
-            <ul className="flex flex-col gap-1">
-              <SidebarLink to="/post-management" icon={<Megaphone size={18} />} label="공고 관리" />
-              <SidebarLink to="/support-management" icon={<ClipboardList size={18} />} label="지원 내역 관리" />
-            </ul>
-          )}
-        </div>
+        ))}
       </nav>
     </aside>
-  );
-};
-
-// 🔗 NavLink 스타일 구성
-interface SidebarLinkProps {
-  to: string;
-  icon: React.ReactNode;
-  label: string;
-}
-
-const SidebarLink = ({ to, icon, label }: SidebarLinkProps) => {
-  return (
-    <NavLink
-      to={to}
-      className={({ isActive }) =>
-        `flex items-center gap-2 px-3 py-2 rounded-md transition-colors duration-150 ${
-          isActive
-            ? "bg-yellow-100 text-yellow-700 font-semibold"
-            : "text-gray-700 hover:bg-gray-100"
-        }`
-      }
-    >
-      <span className="text-gray-500">{icon}</span>
-      <span>{label}</span>
-    </NavLink>
   );
 };
 

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { NavLink } from "react-router-dom";
 import {
   Users,
@@ -11,6 +11,11 @@ import {
 } from "lucide-react";
 
 const Sidebar = () => {
+  // 각 섹션 열림 상태 관리
+  const [isUserOpen, setIsUserOpen] = useState(true);
+  const [isStudyOpen, setIsStudyOpen] = useState(true);
+  const [isPostOpen, setIsPostOpen] = useState(true);
+
   return (
     <aside className="w-64 min-h-screen bg-white border-r border-gray-200 flex flex-col p-4">
       {/* 상단 제목 */}
@@ -18,39 +23,72 @@ const Sidebar = () => {
 
       {/* 메뉴 섹션 */}
       <nav className="flex flex-col gap-6 text-[15px] text-gray-700 font-medium">
+        
         {/* 회원 관리 */}
         <div>
-          <div className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2">
+          <div
+            className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer"
+            onClick={() => setIsUserOpen(!isUserOpen)}
+          >
             <span>회원 관리</span>
+            <ChevronDown
+              size={16}
+              className={`text-gray-400 transition-transform duration-200 ${
+                isUserOpen ? "rotate-0" : "-rotate-90"
+              }`}
+            />
           </div>
-          <ul className="flex flex-col gap-1">
-            <SidebarLink to="/user-management" icon={<Users size={18} />} label="유저 관리" />
-            <SidebarLink to="/withdraw-management" icon={<UserX size={18} />} label="탈퇴 관리" />
-          </ul>
+          {isUserOpen && (
+            <ul className="flex flex-col gap-1">
+              <SidebarLink to="/user-management" icon={<Users size={18} />} label="유저 관리" />
+              <SidebarLink to="/withdraw-management" icon={<UserX size={18} />} label="탈퇴 관리" />
+            </ul>
+          )}
         </div>
 
         {/* 스터디 관리 */}
         <div>
-          <div className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2">
+          <div
+            className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer"
+            onClick={() => setIsStudyOpen(!isStudyOpen)}
+          >
             <span>스터디 관리</span>
-            <ChevronDown size={16} className="text-gray-400" />
+            <ChevronDown
+              size={16}
+              className={`text-gray-400 transition-transform duration-200 ${
+                isStudyOpen ? "rotate-0" : "-rotate-90"
+              }`}
+            />
           </div>
-          <ul className="flex flex-col gap-1">
-            <SidebarLink to="/lecture-management" icon={<BookOpen size={18} />} label="강의 관리" />
-            <SidebarLink to="/study-group-management" icon={<ClipboardList size={18} />} label="스터디 그룹 관리" />
-            <SidebarLink to="/review-management" icon={<Star size={18} />} label="리뷰 관리" />
-          </ul>
+          {isStudyOpen && (
+            <ul className="flex flex-col gap-1">
+              <SidebarLink to="/lecture-management" icon={<BookOpen size={18} />} label="강의 관리" />
+              <SidebarLink to="/study-group-management" icon={<ClipboardList size={18} />} label="스터디 그룹 관리" />
+              <SidebarLink to="/review-management" icon={<Star size={18} />} label="리뷰 관리" />
+            </ul>
+          )}
         </div>
 
         {/* 스터디 구인 공고 관리 */}
         <div>
-          <div className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2">
+          <div
+            className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer"
+            onClick={() => setIsPostOpen(!isPostOpen)}
+          >
             <span>스터디 구인 공고 관리</span>
+            <ChevronDown
+              size={16}
+              className={`text-gray-400 transition-transform duration-200 ${
+                isPostOpen ? "rotate-0" : "-rotate-90"
+              }`}
+            />
           </div>
-          <ul className="flex flex-col gap-1">
-            <SidebarLink to="/post-management" icon={<Megaphone size={18} />} label="공고 관리" />
-            <SidebarLink to="/support-management" icon={<ClipboardList size={18} />} label="지원 내역 관리" />
-          </ul>
+          {isPostOpen && (
+            <ul className="flex flex-col gap-1">
+              <SidebarLink to="/post-management" icon={<Megaphone size={18} />} label="공고 관리" />
+              <SidebarLink to="/support-management" icon={<ClipboardList size={18} />} label="지원 내역 관리" />
+            </ul>
+          )}
         </div>
       </nav>
     </aside>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -10,10 +10,10 @@ import {
   ChevronDown,
 } from "lucide-react";
 
-//메뉴 데이터 타입 정의
+// 메뉴 데이터 타입 정의
 interface MenuItem {
   to: string;
-  icon: React.ReactNode;
+  icon: React.ElementType; // PR 반영
   label: string;
 }
 
@@ -22,11 +22,11 @@ interface MenuSection {
   items: MenuItem[];
 }
 
-//메뉴 리스트 컴포넌트 (각 섹션 안에서 사용)
+// 메뉴 리스트 컴포넌트 (각 섹션 안에서 사용)
 const SidebarLinks = ({ items }: { items: MenuItem[] }) => {
   return (
     <ul className="flex flex-col gap-1">
-      {items.map(({ to, icon, label }) => (
+      {items.map(({ to, icon: Icon, label }) => (
         <li key={to}>
           <NavLink
             to={to}
@@ -38,7 +38,9 @@ const SidebarLinks = ({ items }: { items: MenuItem[] }) => {
               }`
             }
           >
-            <span className="text-gray-500">{icon}</span>
+            <span className="text-gray-500">
+              <Icon size={18} /> {/* 렌더링 시 한 번만 size 지정 */}
+            </span>
             <span>{label}</span>
           </NavLink>
         </li>
@@ -48,54 +50,49 @@ const SidebarLinks = ({ items }: { items: MenuItem[] }) => {
 };
 
 const Sidebar = () => {
-  //각 섹션 열림 상태
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     user: true,
     study: true,
     post: true,
   });
 
-  //섹션 토글 핸들러
   const toggleSection = (key: string) => {
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
-  //메뉴 구성 데이터 (여기만 수정하면 메뉴 추가 가능)
+  // 메뉴 구성 데이터 (아이콘 간략화)
   const menuSections: Record<string, MenuSection> = {
     user: {
       title: "회원 관리",
       items: [
-        { to: "/user-management", icon: <Users size={18} />, label: "유저 관리" },
-        { to: "/withdraw-management", icon: <UserX size={18} />, label: "탈퇴 관리" },
+        { to: "/user-management", icon: Users, label: "유저 관리" },
+        { to: "/withdraw-management", icon: UserX, label: "탈퇴 관리" },
       ],
     },
     study: {
       title: "스터디 관리",
       items: [
-        { to: "/lecture-management", icon: <BookOpen size={18} />, label: "강의 관리" },
-        { to: "/study-group-management", icon: <ClipboardList size={18} />, label: "스터디 그룹 관리" },
-        { to: "/review-management", icon: <Star size={18} />, label: "리뷰 관리" },
+        { to: "/lecture-management", icon: BookOpen, label: "강의 관리" },
+        { to: "/study-group-management", icon: ClipboardList, label: "스터디 그룹 관리" },
+        { to: "/review-management", icon: Star, label: "리뷰 관리" },
       ],
     },
     post: {
       title: "스터디 구인 공고 관리",
       items: [
-        { to: "/post-management", icon: <Megaphone size={18} />, label: "공고 관리" },
-        { to: "/support-management", icon: <ClipboardList size={18} />, label: "지원 내역 관리" },
+        { to: "/post-management", icon: Megaphone, label: "공고 관리" },
+        { to: "/support-management", icon: ClipboardList, label: "지원 내역 관리" },
       ],
     },
   };
 
   return (
     <aside className="w-64 min-h-screen bg-white border-r border-gray-200 flex flex-col p-4">
-      {/* 상단 제목 */}
       <h2 className="text-gray-900 font-bold text-lg mb-6">관리자 패널</h2>
 
-      {/* 메뉴 섹션 */}
       <nav className="flex flex-col gap-6 text-[15px] text-gray-700 font-medium">
         {Object.entries(menuSections).map(([key, section]) => (
           <div key={key}>
-            
             {/* 섹션 헤더 */}
             <div
               className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-2 cursor-pointer select-none"

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 import {
   Users,
   UserX,

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -10,7 +10,7 @@ import {
   ChevronDown,
 } from "lucide-react";
 
-// 메뉴 데이터 타입 정의
+//메뉴 데이터 타입 정의
 interface MenuItem {
   to: string;
   icon: React.ReactNode;
@@ -22,7 +22,7 @@ interface MenuSection {
   items: MenuItem[];
 }
 
-// 📦 메뉴 리스트 컴포넌트 (각 섹션 안에서 사용)
+//메뉴 리스트 컴포넌트 (각 섹션 안에서 사용)
 const SidebarLinks = ({ items }: { items: MenuItem[] }) => {
   return (
     <ul className="flex flex-col gap-1">
@@ -48,19 +48,19 @@ const SidebarLinks = ({ items }: { items: MenuItem[] }) => {
 };
 
 const Sidebar = () => {
-  // 각 섹션 열림 상태
+  //각 섹션 열림 상태
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     user: true,
     study: true,
     post: true,
   });
 
-  // 섹션 토글 핸들러
+  //섹션 토글 핸들러
   const toggleSection = (key: string) => {
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
-  // 📚 메뉴 구성 데이터 (여기만 수정하면 메뉴 추가 가능)
+  //메뉴 구성 데이터 (여기만 수정하면 메뉴 추가 가능)
   const menuSections: Record<string, MenuSection> = {
     user: {
       title: "회원 관리",


### PR DESCRIPTION
## 작업 내용
모든 페이지에 들어갈 사이드 바 컴포넌트의 제작,
 React, React-router-dom 설정으로 사이드 바 메뉴 클릭 시 페이지 기동 구현
사이드 바 토글 기능 구현 및 아이콘 추가

---

## 관련 이슈
Closes #2

---

## 스크린샷 (선택)
 
<img width="256" height="500" alt="image" src="https://github.com/user-attachments/assets/28155115-13b0-4846-93e9-e89b32f329a3" />
