### PR TITLE
[Fix 공고관리 테이블 및 로그인페이지 이슈 수정]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,22 @@ import Dashboard from './pages/Dashboard'
 import StudyApplicationPage from './pages/StudyApplicationPage'
 import { LectureManagementPage } from './pages/LectureManagementPage'
 import RecruitmentManagementPage from './pages/RecruitmentManagementPage'
+import { AdminProtectedRoute } from './components/AdminProtectedRoute'
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route index element={<AdminLoginPage />} />
-        <Route element={<Layout />}>
+        <Route path="login" element={<AdminLoginPage />} />
+
+        <Route
+          element={
+            <AdminProtectedRoute>
+              <Layout />
+            </AdminProtectedRoute>
+          }
+        >
           <Route path="danbi" element={<DanbiTestPage />} />
           <Route path="wonhee" element={<WonheeTestPage />} />
           <Route path="hy" element={<HYTestPage />} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,7 +13,7 @@ export default function Layout(): ReactElement {
           <Sidebar />
         </aside>
 
-        <main className="min-h-[70vh] flex-1 rounded-2xl border border-black/5 bg-white">
+        <main className="min-h-[70vh] flex-1 rounded-2xl border border-black/5 bg-gray-50">
           <div className="p-6">
             <Outlet />
           </div>

--- a/src/components/login/AdminLoginButton.tsx
+++ b/src/components/login/AdminLoginButton.tsx
@@ -1,6 +1,5 @@
 import { forwardRef } from 'react'
 import { Button, type ButtonProps } from '../buttons/Buttons'
-import { Spinner } from '../Spinner'
 import { cn } from '../../utils/cn'
 
 type AdminLoginButtonProps = Omit<
@@ -45,7 +44,6 @@ export const AdminLoginButton = forwardRef<
         )}
         {...rest}
       >
-        {isLoading && <Spinner size={18} />}
         <span className={isLoading ? 'opacity-90' : ''}>
           {children ?? '접속하기'}
         </span>

--- a/src/components/login/ErrorModal.tsx
+++ b/src/components/login/ErrorModal.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from 'lucide-react'
 import Modal from '../modal/Modal'
 import RoundBox from '../modal/Roundbox'
 
@@ -16,8 +17,20 @@ export const LoginErrorModal = ({
 
   return (
     <Modal isOn={isOn} onBackgroundClick={onClose}>
-      <RoundBox padding="md" className="w-[360px] space-y-4 text-center">
-        <p className="text-sm text-neutral-800">{message}</p>
+      <RoundBox
+        padding="md"
+        className="h-[230px] w-[360px] space-y-4 text-center"
+      >
+        <div className="flex justify-center">
+          <AlertTriangle
+            className="text-amber-500"
+            size={80}
+            strokeWidth={2.2}
+          />
+        </div>
+        <p className="text-lg whitespace-pre-line text-neutral-800">
+          {message}
+        </p>
         <button
           onClick={onClose}
           className="rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white"

--- a/src/components/login/ErrorModal.tsx
+++ b/src/components/login/ErrorModal.tsx
@@ -1,0 +1,30 @@
+import Modal from '../modal/Modal'
+import RoundBox from '../modal/Roundbox'
+
+interface LoginErrorModalProps {
+  isOn: boolean
+  message: string
+  onClose: () => void
+}
+
+export const LoginErrorModal = ({
+  isOn,
+  message,
+  onClose,
+}: LoginErrorModalProps) => {
+  if (!isOn) return null
+
+  return (
+    <Modal isOn={isOn} onBackgroundClick={onClose}>
+      <RoundBox padding="md" className="w-[360px] space-y-4 text-center">
+        <p className="text-sm text-neutral-800">{message}</p>
+        <button
+          onClick={onClose}
+          className="rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white"
+        >
+          확인
+        </button>
+      </RoundBox>
+    </Modal>
+  )
+}

--- a/src/components/recruitments/filter/RecruitmentFilterSection.tsx
+++ b/src/components/recruitments/filter/RecruitmentFilterSection.tsx
@@ -44,7 +44,9 @@ export const RecruitmentFilterSection = ({
         <div className="flex w-full justify-end sm:w-auto">
           <StatusSelect
             value={statusFilter}
-            onChange={setStatusFilter}
+            onChange={(nextStatus) => {
+              setStatusFilter(nextStatus)
+            }}
             className="h-10 w-40"
           />
         </div>

--- a/src/components/recruitments/filter/StatusSelect.tsx
+++ b/src/components/recruitments/filter/StatusSelect.tsx
@@ -1,5 +1,6 @@
-import { Select } from '../../FormUI'
 import type { RecruitmentStatusApi } from '../../../types/recruitments'
+import { useState } from 'react'
+import { Accordion } from '../../Accordion/Accordion'
 
 interface StatusSelectProps {
   value: RecruitmentStatusApi | '전체'
@@ -7,18 +8,48 @@ interface StatusSelectProps {
   className?: string
 }
 
-export const StatusSelect = ({ value, onChange }: StatusSelectProps) => {
+const OPTIONS: Array<RecruitmentStatusApi | '전체'> = ['전체', '모집중', '마감']
+
+export const StatusSelect = ({
+  value,
+  onChange,
+  className,
+}: StatusSelectProps) => {
+  const [open, setOpen] = useState('')
+  const header = value === '전체' ? '전체 상태' : `${value}`
   return (
-    <Select
-      value={value}
-      onChange={(event) =>
-        onChange(event.target.value as RecruitmentStatusApi | '전체')
-      }
-      className="w-48"
-    >
-      <option value="전체">전체 상태</option>
-      <option value="모집중">모집중</option>
-      <option value="마감">마감</option>
-    </Select>
+    <div className={className}>
+      <Accordion
+        value={open}
+        onValueChange={setOpen}
+        selectedLabels={{ '0': header }}
+      >
+        <div title="상태">
+          <div className="absolute z-20 w-40 overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg">
+            {OPTIONS.map((option) => {
+              const selected = option === value
+              return (
+                <button
+                  key={option}
+                  onClick={() => {
+                    onChange(option)
+                    setOpen('')
+                  }}
+                  className={[
+                    'flex w-full items-center justify-between px-3 py-3 text-sm',
+                    selected
+                      ? 'bg-amber-100 font-medium text-gray-900'
+                      : 'text-gray-700',
+                    'transition-colors hover:bg-amber-100',
+                  ].join(' ')}
+                >
+                  <span>{option === '전체' ? '전체 상태' : option}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </Accordion>
+    </div>
   )
 }

--- a/src/components/recruitments/table/Column.tsx
+++ b/src/components/recruitments/table/Column.tsx
@@ -36,7 +36,7 @@ export const recruitmentColumns = [
     render: (cellValue: unknown, _fullRow: Recruitment) => {
       const closeAtValue = (cellValue as Recruitment['closeAt']) ?? ''
       return (
-        <span className="text-neutral text-[12px]">
+        <span className="text-[12px] text-neutral-700">
           {formatDate(closeAtValue)}
         </span>
       )

--- a/src/components/recruitments/table/RecruitmentStatusBadge.tsx
+++ b/src/components/recruitments/table/RecruitmentStatusBadge.tsx
@@ -1,11 +1,13 @@
 import { Badge } from '../../Badge'
 import type { RecruitmentStatusApi } from '../../../types/recruitments'
 
-interface Props {
+interface RecruitmentStatusBadgeProps {
   status: RecruitmentStatusApi
 }
 
-export const RecruitmentStatusBadge = ({ status }: Props) => {
+export const RecruitmentStatusBadge = ({
+  status,
+}: RecruitmentStatusBadgeProps) => {
   const variant: 'success' | 'default' =
     status === '모집중' ? 'success' : 'default'
 

--- a/src/pages/AdminLoginPage.tsx
+++ b/src/pages/AdminLoginPage.tsx
@@ -1,11 +1,12 @@
 import { Eye, EyeOff, Lock, Mail } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AdminLoginButton } from '../components/login/AdminLoginButton'
 import { BrandLogo } from '../components/login/BrandLogo'
 import { FormField, TextField } from '../components/FormUI'
 import api from '../lib/axios'
-import { setAccessToken } from '../lib/token'
+import { getAccessToken, setAccessToken } from '../lib/token'
 import { LoginErrorModal } from '../components/login/ErrorModal'
+import { parseJwt } from '../lib/authz'
 
 export default function AdminLoginPage() {
   const [showPassword, setShowPassword] = useState(false)
@@ -14,6 +15,18 @@ export default function AdminLoginPage() {
   //   const [pwError, setPwError] = useState<string | undefined>()
   const [errorModalOn, setErrorModalOn] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
+
+  // 이미 로그인되어있을 경우 진입을 차단합니당.
+  useEffect(() => {
+    const accessToken = getAccessToken() // 쿠키에 저장된 액세스토큰 불러오기 (없으면 null)
+    const claims = parseJwt(accessToken) // JWT 내부 정보를 추출함
+    const isExpired = claims?.exp ? claims.exp * 1000 < Date.now() : true // 토큰만료여부를 판단
+
+    if (accessToken && !isExpired) {
+      // 이미 로그인되어 잇는거니??
+      window.location.replace('/userlist') // 응, 그러면 안되 돌아가
+    }
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/pages/AdminLoginPage.tsx
+++ b/src/pages/AdminLoginPage.tsx
@@ -5,12 +5,15 @@ import { BrandLogo } from '../components/login/BrandLogo'
 import { FormField, TextField } from '../components/FormUI'
 import api from '../lib/axios'
 import { setAccessToken } from '../lib/token'
+import { LoginErrorModal } from '../components/login/ErrorModal'
 
 export default function AdminLoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   //   const [emailError, setEmailError] = useState<string | undefined>()
   //   const [pwError, setPwError] = useState<string | undefined>()
+  const [errorModalOn, setErrorModalOn] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -32,104 +35,117 @@ export default function AdminLoginPage() {
         setAccessToken(accessToken)
         window.location.href = '/userlist'
       } else {
-        alert('세션이 만료되어 다시 로그인해 주세요.')
+        setErrorMessage(
+          '이메일 또는 비밀번호가 올바르지 않아요.\n다시 확인해 주세요.'
+        )
+        setErrorModalOn(true)
       }
       // await api.post("v1/auth/login", {email, password});
     } catch {
-      /* 에러제거하자제발 */
+      setErrorMessage(
+        '이메일 또는 비밀번호가 올바르지 않아요.\n다시 확인해 주세요.'
+      )
+      setErrorModalOn(true)
     } finally {
       setIsLoading(false)
     }
   }
 
   return (
-    <main className="grid min-h-screen grid-cols-1 bg-white md:grid-cols-[1fr_720px]">
-      <section className="flex items-center justify-center px-6">
-        <div className="flex w-full max-w-sm flex-col items-center text-center">
-          <BrandLogo />
-          <h1 className="mt-4 text-[26px] font-extrabold tracking-tight text-neutral-900 select-none">
-            관리자 로그인
-          </h1>
+    <>
+      <main className="grid min-h-screen grid-cols-1 bg-white md:grid-cols-[1fr_720px]">
+        <section className="flex items-center justify-center px-6">
+          <div className="flex w-full max-w-sm flex-col items-center text-center">
+            <BrandLogo />
+            <h1 className="mt-4 text-[26px] font-extrabold tracking-tight text-neutral-900 select-none">
+              관리자 로그인
+            </h1>
 
-          <p className="mt-10 text-[12.5px] leading-5 text-neutral-500 select-none">
-            <span className="font-semibold text-amber-500">관리자</span>
-            <span className="ml-1 text-amber-500">계정</span>을 통해 로그인을
-            진행해주세요.
-          </p>
-          <form className="mt-3 w-full" onSubmit={handleSubmit}>
-            <FormField
-              id="email"
-              label={<span className="sr-only">이메일</span>}
-              className="mb-2 space-y-0"
-            >
-              <TextField
+            <p className="mt-10 text-[12.5px] leading-5 text-neutral-500 select-none">
+              <span className="font-semibold text-amber-500">관리자</span>
+              <span className="ml-1 text-amber-500">계정</span>을 통해 로그인을
+              진행해주세요.
+            </p>
+            <form className="mt-3 w-full" onSubmit={handleSubmit}>
+              <FormField
                 id="email"
-                name="email"
-                type="email"
-                placeholder="example@company.com"
-                leftIcon={<Mail className="h-5 w-5 text-amber-700" />}
-                className="h-12 text-[15px]"
-                autoComplete="username"
-                required
-              />
-            </FormField>
-            <FormField
-              id="password"
-              label={<span className="sr-only">비밀번호</span>}
-              className="space-y-1.5"
-            >
-              <TextField
+                label={<span className="sr-only">이메일</span>}
+                className="mb-2 space-y-0"
+              >
+                <TextField
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="example@company.com"
+                  leftIcon={<Mail className="h-5 w-5 text-amber-700" />}
+                  className="h-12 text-[15px]"
+                  autoComplete="username"
+                  required
+                />
+              </FormField>
+              <FormField
                 id="password"
-                name="password"
-                type={showPassword ? 'text' : 'password'}
-                placeholder="비밀번호를 입력하세요"
-                leftIcon={<Lock className="h-5 w-5 text-amber-700" />}
-                rightSlot={
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    className="text-neutral-400 transition hover:text-neutral-600"
-                    aria-label={
-                      showPassword ? '비밀번호 숨기기' : '비밀번호 보기'
-                    }
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-6 w-6 text-amber-800" />
-                    ) : (
-                      <Eye className="h-6 w-6 text-amber-800" />
-                    )}
-                  </button>
-                }
-                className="h-12 text-[15px]"
-                autoComplete="current-password"
-                required
-              />
-            </FormField>
+                label={<span className="sr-only">비밀번호</span>}
+                className="space-y-1.5"
+              >
+                <TextField
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="비밀번호를 입력하세요"
+                  leftIcon={<Lock className="h-5 w-5 text-amber-700" />}
+                  rightSlot={
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="text-neutral-400 transition hover:text-neutral-600"
+                      aria-label={
+                        showPassword ? '비밀번호 숨기기' : '비밀번호 보기'
+                      }
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-6 w-6 text-amber-800" />
+                      ) : (
+                        <Eye className="h-6 w-6 text-amber-800" />
+                      )}
+                    </button>
+                  }
+                  className="h-12 text-[15px]"
+                  autoComplete="current-password"
+                  required
+                />
+              </FormField>
 
-            <AdminLoginButton
-              type="submit"
-              full
-              className="mt-5"
-              disabled={isLoading}
-              aria-busy={isLoading}
-              isLoading={isLoading}
-            >
-              {isLoading ? '접속 중' : '접속하기'}
-            </AdminLoginButton>
-          </form>
-        </div>
-      </section>
+              <AdminLoginButton
+                type="submit"
+                full
+                className="mt-5"
+                disabled={isLoading}
+                aria-busy={isLoading}
+                isLoading={isLoading}
+              >
+                {isLoading ? '접속 중' : '접속하기'}
+              </AdminLoginButton>
+            </form>
+          </div>
+        </section>
 
-      <aside
-        aria-hidden
-        className="relative hidden overflow-hidden bg-[#FFF7ED] md:block"
-      >
-        <div className="absolute inset-0 flex items-center justify-center">
-          <span className="text-[150vh] leading-none font-extrabold text-[#fbbf24]/20 select-none">
-            S
-          </span>
-        </div>
-      </aside>
-    </main>
+        <aside
+          aria-hidden
+          className="relative hidden overflow-hidden bg-[#FFF7ED] md:block"
+        >
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-[150vh] leading-none font-extrabold text-[#fbbf24]/20 select-none">
+              S
+            </span>
+          </div>
+        </aside>
+      </main>
+      <LoginErrorModal
+        isOn={errorModalOn}
+        message={errorMessage}
+        onClose={() => setErrorModalOn(false)}
+      />
+    </>
   )
 }

--- a/src/pages/RecruitmentManagementPage.tsx
+++ b/src/pages/RecruitmentManagementPage.tsx
@@ -5,6 +5,7 @@ import { Pagination } from '../components/pagination/Pagination'
 import { RecruitmentFilterSection } from '../components/recruitments/filter/RecruitmentFilterSection'
 import type { Recruitment, RecruitmentStatusApi } from '../types/recruitments'
 import { RecruitmentTableSection } from '../components/recruitments/table/RecruitmentTableSection'
+import { Inbox } from 'lucide-react'
 
 const PAGE_SIZE = 10
 
@@ -76,6 +77,8 @@ const RecruitmentManagementPage = () => {
     return filteredRecruitmentList
   }, [statusFilter, debouncedSearchText, selectedTags])
 
+  const hasNoData = filteredRecruitments.length === 0
+
   const totalPages = Math.max(
     1,
     Math.ceil(filteredRecruitments.length / PAGE_SIZE)
@@ -86,6 +89,13 @@ const RecruitmentManagementPage = () => {
     const endIndex = startIndex + PAGE_SIZE
     return filteredRecruitments.slice(startIndex, endIndex)
   }, [filteredRecruitments, currentPage])
+
+  const resetFilters = () => {
+    setSearchText('')
+    setStatusFilter('전체')
+    setSelectedTags([])
+    setCurrentPage(1)
+  }
 
   return (
     <div className="space-y-4 p-6">
@@ -117,21 +127,50 @@ const RecruitmentManagementPage = () => {
         </span>
         건
       </div>
-      <RecruitmentTableSection
-        data={paginatedRecruitments}
-        onRowClick={(row) => {
-          console.log('row clicked:', row.id)
-        }}
-      />
 
-      {totalPages > 1 && (
-        <div className="flex justify-center">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={setCurrentPage}
+      {hasNoData ? (
+        <section className="rounded-xl border border-neutral-200 bg-white shadow-sm">
+          <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+            <Inbox className="mb-2 h-10 w-10 text-neutral-400" />
+            <h3 className="text-base font-semibold text-neutral-800">
+              조건에 맞는 공고가 없습니다.
+            </h3>
+            <p className="max-w-prose text-sm text-neutral-500">
+              검색어 또는 태그를 조정해보세요.
+            </p>
+            {(searchText.trim() ||
+              selectedTags.length ||
+              statusFilter !== '전체') && (
+              <div className="mt-4">
+                <button
+                  onClick={resetFilters}
+                  className="rounded-lg border border-neutral-300 bg-white px-3 py-1.5 text-sm text-neutral-700 hover:bg-neutral-50"
+                >
+                  초기화
+                </button>
+              </div>
+            )}
+          </div>
+        </section>
+      ) : (
+        <>
+          <RecruitmentTableSection
+            data={paginatedRecruitments}
+            onRowClick={(row) => {
+              console.log('row clicked:', row.id)
+            }}
           />
-        </div>
+
+          {totalPages > 1 && (
+            <div className="flex justify-center">
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
+            </div>
+          )}
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
# <주의!!!!! 꼭 읽어주세요ㅠㅠㅠㅠ>
<img width="556" height="348" alt="image" src="https://github.com/user-attachments/assets/e287198f-a015-49f7-93ac-dcdc2360aa56" />

- 로직 변경과 직접 관련 없는 프리티어로 인한 포맷 변경이 일부 포함되어 있습니다.
- 리뷰 시 톱니바퀴 탭에서 ⚙️ → **Hide whitespace**를 적용하시면 기능 변경 위주로 확인하실 수 있습니다.

## 작업 내용
- 로그인 페이지 연결됨에 따라서, 지난 이슈때 진행하지 못했던 부분들을 수정했습니다.
1. 코드 오타 수정 및 프롭스만 적혀있던거 상세하게 수정
2. 목록에 아무 내용이 없을 경우, 출력될 화면 제작
3. App.tsx에 프로텍트 라우팅 설정, (로그인x 페이지 진입 시 튕김)
4. 로그인버튼 눌렀을때, 로딩스피너가 중복으로 뜨는 부분 수정
5. 로그인에러모달 제작
6. 이미 로그인 되어 있는 상황에서 뒤로가기 혹은 로그인페이지로 갈 경우 못가도록 막음.

---

## 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 통과
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요. ex) Closes #123 -->

Closes #108 

---

## 스크린샷 (선택)
1. 빌드 완료~
<img width="1905" height="966" alt="image" src="https://github.com/user-attachments/assets/f385fa90-bc56-4c23-895b-6a08b9830381" />
2.데모

[lastissue.webm](https://github.com/user-attachments/assets/ba1305a4-c389-4665-a205-d4b542cfe88a)
