### PR TITLE
[Feat] : 구인공고관리페이지 탠스택 쿼리 연동준비 - api연동전 

### DIFF
--- a/src/api/fetchRecruitments.ts
+++ b/src/api/fetchRecruitments.ts
@@ -13,3 +13,14 @@ export type FetchRecruitmentsReturn = {
   pageSize: number
   totalCount: number
 }
+
+export const fetchRecruitments = async (
+  params: RecruitmentRequestParams
+): Promise<FetchRecruitmentsReturn> => {
+  const url = '/v1/recruitments/admin/'
+  const { data } = await api.get<RecruitmentListResponseDTO>(url, { params })
+
+  const items = data.results.map((dto: RecruitmentDTO) =>
+    mapRecruitmentDTO(dto)      // dto -> ui 매핑
+  )
+}

--- a/src/api/fetchRecruitments.ts
+++ b/src/api/fetchRecruitments.ts
@@ -17,10 +17,17 @@ export type FetchRecruitmentsReturn = {
 export const fetchRecruitments = async (
   params: RecruitmentRequestParams
 ): Promise<FetchRecruitmentsReturn> => {
-  const url = '/v1/recruitments/admin/'
+  const url = '/v1/recruitments/admin/' // 엔드포인트 좀 더 보고 진행할게요.
   const { data } = await api.get<RecruitmentListResponseDTO>(url, { params })
 
-  const items = data.results.map((dto: RecruitmentDTO) =>
-    mapRecruitmentDTO(dto)      // dto -> ui 매핑
+  const items = data.results.map(
+    (dto: RecruitmentDTO) => mapRecruitmentDTO(dto) // dto -> ui 매핑
   )
+
+  return {
+    items,
+    page: data.page,
+    pageSize: data.page_size,
+    totalCount: data.total_count,
+  }
 }

--- a/src/api/fetchRecruitments.ts
+++ b/src/api/fetchRecruitments.ts
@@ -1,0 +1,15 @@
+import api from '../lib/axios'
+import {
+  type Recruitment,
+  type RecruitmentListResponseDTO,
+  type RecruitmentDTO,
+  mapRecruitmentDTO,
+} from '../types/recruitments'
+import type { RecruitmentRequestParams } from '../hooks/recruitments/buildQueryParams'
+
+export type FetchRecruitmentsReturn = {
+  items: Recruitment[]
+  page: number
+  pageSize: number
+  totalCount: number
+}

--- a/src/api/fetchRecruitments.ts
+++ b/src/api/fetchRecruitments.ts
@@ -8,22 +8,22 @@ import {
 import type { RecruitmentRequestParams } from '../hooks/recruitments/buildQueryParams'
 
 export type FetchRecruitmentsReturn = {
-  items: Recruitment[]
+  items: Recruitment[] // 공고목록
   page: number
   pageSize: number
-  totalCount: number
+  totalCount: number // 전체 페이지수
 }
-
+// api호출함수
 export const fetchRecruitments = async (
-  params: RecruitmentRequestParams
+  params: RecruitmentRequestParams // 페이지 번호, 검색어 등등
 ): Promise<FetchRecruitmentsReturn> => {
-  const url = '/v1/recruitments/admin/' // 엔드포인트 좀 더 보고 진행할게요.
+  const url = '/v1/recruitments/admin/' // 엔드포인트 좀 더 보고 진행할게요, admin/ 이게아니라 왔다갔다함 ...
   const { data } = await api.get<RecruitmentListResponseDTO>(url, { params })
-
+  // 서버에서 받은 results 배열을 UI 형식으로 모두 변환해요.
   const items = data.results.map(
     (dto: RecruitmentDTO) => mapRecruitmentDTO(dto) // dto -> ui 매핑
   )
-
+  // ui에서 바로 사용할 수 있도록 포맷 통일해서 반환하기.
   return {
     items,
     page: data.page,

--- a/src/hooks/recruitments/buildQueryParams.ts
+++ b/src/hooks/recruitments/buildQueryParams.ts
@@ -10,4 +10,12 @@ export const buildRecruitmentsQueryParams = (
 ): RecruitmentRequestParams => {
     const normalizedPageSize = clampNumber(options.pageSize ?? 20, 1, 100);
     const normalizedPageNumber = Math.max(1, options.pageNumber ?? 1);
+
+    const trimmedSearchText = (options.searchText ?? '').trim();
+    if (trimmedSearchText) {
+        queryParams.search = trimmedSearchText;
+    }
+
+    
+
 }

--- a/src/hooks/recruitments/buildQueryParams.ts
+++ b/src/hooks/recruitments/buildQueryParams.ts
@@ -24,4 +24,8 @@ export const buildRecruitmentsQueryParams = (
   if (options.statusFilter) {
     queryParams.status = options.statusFilter
   }
+
+  if (options.selectedTags && options.selectedTags.length>0) {
+    queryParams.tags = options.selectedTags.join(',')
+  }
 }

--- a/src/hooks/recruitments/buildQueryParams.ts
+++ b/src/hooks/recruitments/buildQueryParams.ts
@@ -6,16 +6,22 @@ const clampNumber = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max)
 
 export const buildRecruitmentsQueryParams = (
-    options: AdminRecruitmentsParams
+  options: AdminRecruitmentsParams
 ): RecruitmentRequestParams => {
-    const normalizedPageSize = clampNumber(options.pageSize ?? 20, 1, 100);
-    const normalizedPageNumber = Math.max(1, options.pageNumber ?? 1);
+  const normalizedPageSize = clampNumber(options.pageSize ?? 20, 1, 100)
+  const normalizedPageNumber = Math.max(1, options.pageNumber ?? 1)
 
-    const trimmedSearchText = (options.searchText ?? '').trim();
-    if (trimmedSearchText) {
-        queryParams.search = trimmedSearchText;
-    }
+  const queryParams: RecruitmentRequestParams = {
+    page: normalizedPageNumber,
+    page_size: normalizedPageSize
+  }
 
-    
+  const trimmedSearchText = (options.searchText ?? '').trim()
+  if (trimmedSearchText) {
+    queryParams.search = trimmedSearchText
+  }
 
+  if (options.statusFilter) {
+    queryParams.status = options.statusFilter
+  }
 }

--- a/src/hooks/recruitments/buildQueryParams.ts
+++ b/src/hooks/recruitments/buildQueryParams.ts
@@ -1,0 +1,13 @@
+import type { AdminRecruitmentsParams } from './types.local'
+
+export type RecruitmentRequestParams = Record<string, string | number>
+
+const clampNumber = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max)
+
+export const buildRecruitmentsQueryParams = (
+    options: AdminRecruitmentsParams
+): RecruitmentRequestParams => {
+    const normalizedPageSize = clampNumber(options.pageSize ?? 20, 1, 100);
+    const normalizedPageNumber = Math.max(1, options.pageNumber ?? 1);
+}

--- a/src/hooks/recruitments/buildQueryParams.ts
+++ b/src/hooks/recruitments/buildQueryParams.ts
@@ -13,7 +13,7 @@ export const buildRecruitmentsQueryParams = (
 
   const queryParams: RecruitmentRequestParams = {
     page: normalizedPageNumber,
-    page_size: normalizedPageSize
+    page_size: normalizedPageSize,
   }
 
   const trimmedSearchText = (options.searchText ?? '').trim()
@@ -25,7 +25,13 @@ export const buildRecruitmentsQueryParams = (
     queryParams.status = options.statusFilter
   }
 
-  if (options.selectedTags && options.selectedTags.length>0) {
+  if (options.selectedTags && options.selectedTags.length > 0) {
     queryParams.tags = options.selectedTags.join(',')
   }
+
+  if (options.ordering) {
+    queryParams.ordering = options.ordering
+  }
+
+  return queryParams
 }

--- a/src/hooks/recruitments/buildQueryParams.ts
+++ b/src/hooks/recruitments/buildQueryParams.ts
@@ -4,31 +4,32 @@ export type RecruitmentRequestParams = Record<string, string | number>
 
 const clampNumber = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max)
-
+// 검색/필터 옵션을 서버 쿼리 파라미터로 변환할 함수
 export const buildRecruitmentsQueryParams = (
   options: AdminRecruitmentsParams
 ): RecruitmentRequestParams => {
+  // 페이지 기본값 설정 및 제어
   const normalizedPageSize = clampNumber(options.pageSize ?? 20, 1, 100)
   const normalizedPageNumber = Math.max(1, options.pageNumber ?? 1)
-
+  // 기본 파라미터
   const queryParams: RecruitmentRequestParams = {
     page: normalizedPageNumber,
     page_size: normalizedPageSize,
   }
-
+  // 검색어
   const trimmedSearchText = (options.searchText ?? '').trim()
   if (trimmedSearchText) {
     queryParams.search = trimmedSearchText
   }
-
+  // 상태필터
   if (options.statusFilter) {
     queryParams.status = options.statusFilter
   }
-
+  // 선택된 태그가 여러개? -> tag1, tag2 형태로 보냄
   if (options.selectedTags && options.selectedTags.length > 0) {
     queryParams.tags = options.selectedTags.join(',')
   }
-
+  // 정렬
   if (options.ordering) {
     queryParams.ordering = options.ordering
   }

--- a/src/hooks/recruitments/queryKeys.ts
+++ b/src/hooks/recruitments/queryKeys.ts
@@ -1,3 +1,3 @@
-export const AdminRecruitmentsQueryKey = (
+export const adminRecruitmentsQueryKey = (
   queryParams: Record<string, string | number>
 ) => ['admin:recruitments', queryParams] as const

--- a/src/hooks/recruitments/queryKeys.ts
+++ b/src/hooks/recruitments/queryKeys.ts
@@ -1,0 +1,3 @@
+export const AdminRecruitmentsQueryKey = (
+  queryParams: Record<string, string | number>
+) => ['admin:recruitments', queryParams] as const

--- a/src/hooks/recruitments/types.local.ts
+++ b/src/hooks/recruitments/types.local.ts
@@ -1,0 +1,8 @@
+export type AdminRecruitmentsParams = {
+  searchText?: string
+  statusFilter?: '모집중' | '마감'
+  selectedTags?: string[]
+  ordering: 'latest' | 'oldest' | 'views' | 'bookmarks'
+  pageNumber?: number
+  pageSize?: number
+}

--- a/src/hooks/recruitments/types.local.ts
+++ b/src/hooks/recruitments/types.local.ts
@@ -1,8 +1,8 @@
 export type AdminRecruitmentsParams = {
-  searchText?: string
-  statusFilter?: '모집중' | '마감'
-  selectedTags?: string[]
-  ordering: 'latest' | 'oldest' | 'views' | 'bookmarks'
-  pageNumber?: number
-  pageSize?: number
+  searchText?: string // 검색어
+  statusFilter?: '모집중' | '마감' // 상태 필터
+  selectedTags?: string[] // 태그 필터
+  ordering: 'latest' | 'oldest' | 'views' | 'bookmarks' // 정렬 방식
+  pageNumber?: number // 페이지 번호
+  pageSize?: number // 페이지당 출력될 항목의 수
 }

--- a/src/hooks/recruitments/useRecruitmentsQuery.ts
+++ b/src/hooks/recruitments/useRecruitmentsQuery.ts
@@ -1,5 +1,5 @@
 import {
-  keepPreviousData,
+  keepPreviousData, // 페이지 이동할때 이전 데이터를 유지해줍니닷.
   useQuery,
   type UseQueryResult,
 } from '@tanstack/react-query'
@@ -12,13 +12,13 @@ import {
 import type { AdminRecruitmentsParams } from './types.local'
 
 const SECOND = 1_000
-const STALE_TIME_RECRUITMENTS = 30 * SECOND
-
+const STALE_TIME_RECRUITMENTS = 30 * SECOND // 30초 동안 캐시 데이터를 사용합나디
+// 공고 데이터 요청 + 캐싱 + 로딩 및 에러 상태까지 관리해주는 훅
 export const useAdminRecruitmentsQuery = (
   options: AdminRecruitmentsParams
 ): UseQueryResult<FetchRecruitmentsReturn, Error> => {
-  const requestParams = buildRecruitmentsQueryParams(options)
-  const queryFn = () => fetchRecruitments(requestParams)
+  const requestParams = buildRecruitmentsQueryParams(options) // 서버 파라미터 변환
+  const queryFn = () => fetchRecruitments(requestParams) // 실제 api호출
 
   return useQuery<
     FetchRecruitmentsReturn,
@@ -26,9 +26,9 @@ export const useAdminRecruitmentsQuery = (
     FetchRecruitmentsReturn,
     ReturnType<typeof adminRecruitmentsQueryKey>
   >({
-    queryKey: adminRecruitmentsQueryKey(requestParams),
+    queryKey: adminRecruitmentsQueryKey(requestParams), // 캐싱 및 리패치 기준
     queryFn,
-    placeholderData: keepPreviousData,
-    staleTime: STALE_TIME_RECRUITMENTS,
+    placeholderData: keepPreviousData, // 페이지 변경해도 UI 깜빡임을 방지해줌
+    staleTime: STALE_TIME_RECRUITMENTS, // 재요청을 최소화함.
   })
 }

--- a/src/hooks/recruitments/useRecruitmentsQuery.ts
+++ b/src/hooks/recruitments/useRecruitmentsQuery.ts
@@ -1,0 +1,15 @@
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryResult,
+} from '@tanstack/react-query'
+import { AdminRecruitmentsQueryKey } from './queryKeys'
+import { buildRecruitmentsQueryParams } from './buildQueryParams'
+import {
+  fetchRecruitments,
+  type FetchRecruitmentsReturn,
+} from '../../api/fetchRecruitments'
+import type { AdminRecruitmentsParams } from './types.local'
+
+const SECOND = 1_000
+const STALE_TIME_RECRUITMENTS = 30 * SECOND

--- a/src/hooks/recruitments/useRecruitmentsQuery.ts
+++ b/src/hooks/recruitments/useRecruitmentsQuery.ts
@@ -3,7 +3,7 @@ import {
   useQuery,
   type UseQueryResult,
 } from '@tanstack/react-query'
-import { AdminRecruitmentsQueryKey } from './queryKeys'
+import { adminRecruitmentsQueryKey } from './queryKeys'
 import { buildRecruitmentsQueryParams } from './buildQueryParams'
 import {
   fetchRecruitments,
@@ -13,3 +13,22 @@ import type { AdminRecruitmentsParams } from './types.local'
 
 const SECOND = 1_000
 const STALE_TIME_RECRUITMENTS = 30 * SECOND
+
+export const useAdminRecruitmentsQuery = (
+  options: AdminRecruitmentsParams
+): UseQueryResult<FetchRecruitmentsReturn, Error> => {
+  const requestParams = buildRecruitmentsQueryParams(options)
+  const queryFn = () => fetchRecruitments(requestParams)
+
+  return useQuery<
+    FetchRecruitmentsReturn,
+    Error,
+    FetchRecruitmentsReturn,
+    ReturnType<typeof adminRecruitmentsQueryKey>
+  >({
+    queryKey: adminRecruitmentsQueryKey(requestParams),
+    queryFn,
+    placeholderData: keepPreviousData,
+    staleTime: STALE_TIME_RECRUITMENTS,
+  })
+}

--- a/src/pages/RecruitmentManagementPage.tsx
+++ b/src/pages/RecruitmentManagementPage.tsx
@@ -7,9 +7,10 @@ import type { Recruitment, RecruitmentStatusApi } from '../types/recruitments'
 import { RecruitmentTableSection } from '../components/recruitments/table/RecruitmentTableSection'
 import { Inbox } from 'lucide-react'
 import { RecruitmentModal } from '../components/recruitments/modal/RecruitmentModal'
+// import { useAdminRecruitmentsQuery } from '../hooks/recruitments/useRecruitmentsQuery'
 
 const PAGE_SIZE = 10
-
+// 여기서부터
 const TAGS = [
   // 가짜 목데이터
   ['React', 'Frontend'],
@@ -36,7 +37,7 @@ const mockRecruitments: Recruitment[] = Array.from({ length: 15 }).map(
 )
 
 const ALL_TAGS = Array.from(new Set(mockRecruitments.flatMap((r) => r.tags))) // 전체 태그 목록
-
+// 여기까지 목업데이터 입니닷.
 const RecruitmentManagementPage = () => {
   const [searchParams] = useSearchParams()
   const initialPageNumber = Number(searchParams.get('page') ?? '1')
@@ -51,9 +52,21 @@ const RecruitmentManagementPage = () => {
 
   const [selectedRecruitment, setSelectedRecruitment] =
     useState<Recruitment | null>(null)
-
+  // const {
+  //   data: _data,
+  //   isLoading: _isLoading,
+  //   isError: _isError,
+  // } = useAdminRecruitmentsQuery({
+  //   searchText: debouncedSearchText,
+  //   statusFilter: statusFilter === '전체' ? undefined : statusFilter,
+  //   selectedTags,
+  //   ordering: 'latest',
+  //   pageNumber: currentPage,
+  //   pageSize: PAGE_SIZE,
+  // })
   const filteredRecruitments = useMemo(() => {
     let filteredRecruitmentList = mockRecruitments
+    // let filteredRecruitmentList = data?.items ?? []
 
     if (statusFilter !== '전체') {
       filteredRecruitmentList = filteredRecruitmentList.filter(
@@ -80,6 +93,7 @@ const RecruitmentManagementPage = () => {
 
     return filteredRecruitmentList
   }, [statusFilter, debouncedSearchText, selectedTags])
+  // }, [data?.items, debouncedSearchText, statusFilter, selectedTags])
 
   const hasNoData = filteredRecruitments.length === 0
 


### PR DESCRIPTION
## 작업 내용

- 구인공고 관리 페이지 탠스택 쿼리 연동위해 코드 작성하였습니다.
- 실제 데이터 붙일때는 다음 이슈를 열어서 진행할 예정입니다!

---

## 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 통과
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈

Closes #127 

---

## 스크린샷 (선택)
1. 빌드 완~료~
<img width="1920" height="973" alt="image" src="https://github.com/user-attachments/assets/fb8e1cba-2751-4b67-ad7e-0d66ae4b2a1d" />
