### PR TITLE
[fix] : 강의 목록 id 수정 / 강의 모달창 띄워지게 수정(#124)

### DIFF
--- a/src/components/Lecture/LectureModalOutlet.tsx
+++ b/src/components/Lecture/LectureModalOutlet.tsx
@@ -11,7 +11,7 @@ export const LectureModalOutlet = ({ lecture }: LectureModalOutletProps) => (
   <div className="flex max-h-[85vh] flex-col overflow-hidden">
     <div className="flex-1 overflow-y-auto p-6">
       <div className="mx-auto w-full max-w-4xl">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-[380px_1fr]">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {/* 왼쪽 */}
           <section className="space-y-4">
             <div className="relative h-[240px] w-full overflow-hidden rounded-lg border-2 border-blue-400">
@@ -86,7 +86,7 @@ export const LectureModalOutlet = ({ lecture }: LectureModalOutletProps) => (
                 label="원 가격"
                 value={
                   <span className="text-gray-500 line-through">
-                    {lecture.originalPrice.toLocaleString()}원
+                    {(lecture.originalPrice ?? 0).toLocaleString()}원
                   </span>
                 }
                 noBorder
@@ -95,7 +95,7 @@ export const LectureModalOutlet = ({ lecture }: LectureModalOutletProps) => (
                 label="할인된 가격"
                 value={
                   <span className="text-2xl font-bold text-yellow-500">
-                    {lecture.discountPrice.toLocaleString()}원
+                    {(lecture.discountPrice ?? 0).toLocaleString()}원
                   </span>
                 }
                 noBorder

--- a/src/components/Lecture/LectureTable.tsx
+++ b/src/components/Lecture/LectureTable.tsx
@@ -6,6 +6,8 @@ import { LectureThumbnail } from '../Lecture/LectureThumbnail'
 type LectureTableProps = {
   lectures: Lecture[]
   onLectureClick?: (lecture: Lecture) => void
+  currentPage?: number
+  pageSize?: number
 }
 
 type LectureTableData = {
@@ -22,9 +24,12 @@ type LectureTableData = {
 export const LectureTable = ({
   lectures,
   onLectureClick,
+  currentPage = 1,
+  pageSize = 10,
 }: LectureTableProps) => {
+  const startIndex = (currentPage - 1) * pageSize
   const tableData: LectureTableData[] = lectures.map((lecture, index) => ({
-    id: String(index + 1),
+    id: String(startIndex + index + 1),
     thumbnail: lecture.thumbnail,
     title: lecture.title,
     instructor: lecture.instructor,

--- a/src/pages/LectureManagementPage.tsx
+++ b/src/pages/LectureManagementPage.tsx
@@ -108,6 +108,8 @@ export const LectureManagementPage = () => {
             <LectureTable
               lectures={lectures}
               onLectureClick={handleLectureClick}
+              currentPage={currentPage}
+              pageSize={PAGE_SIZE}
             />
 
             {totalPages > 1 && (


### PR DESCRIPTION
## PR 제목


- [fix] : 강의 목록 id 수정 / 강의 모달창 띄워지게 수정(#124)

실제 api에서는 
```
"results": [
        {
            "id": 3958,
            "title": "초절정 파이썬 강좌 (python)",
            "instructor": "샵투월드",
            "thumbnail_img_url": "https://cdn.inflearn.com/wp-content/uploads/python001.jpg",
            "platform": "INFLEARN",
            "url_link": "https://www.inflearn.com/course/초절정-파이썬-강좌-python",
            "categories": [],
            "created_at": "2025-11-03T17:13:11.771176+09:00",
            "updated_at": "2025-11-03T17:13:11.771179+09:00"
        },
```

이렇게 들어와서 아직 상세 모달창에 필요한 값들이 아예 안들어있는 것도 있네요..! 
이 부분은 참고부탁드립니다 :)
 
---

## 작업 내용

-강의 목록 id 인텍스 수정
-모달창 안뜨는 오류 수정

---

## 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 통과
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈

Closes #124 

---

## 스크린샷 (선택)
<img width="742" height="423" alt="스크린샷 2025-11-04 오후 5 52 43" src="https://github.com/user-attachments/assets/dd470aa0-4f25-455a-812e-3383d9922b95" />
