### PR TITLE
[Feat] : PAGEHEADER 제작

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,4 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "../utils/cn";
+import type { PropsWithChildren, ReactNode } from "react";
+

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -35,7 +35,13 @@ export const PageHeader = ({
             'flex items-center gap-3',
             textAlign === 'center' && 'md:justify-center'
           )}
-        ></div>
+        >
+          {IconComponent && (
+            <div className="grid h-11 w-11 place-items-center rounded-xl border border-neutral-300">
+              <IconComponent className="text-neurtal-700 h-5 w-5" />
+            </div>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -2,11 +2,9 @@ import { cn } from '../utils/cn'
 import type { PageHeaderProps } from '../types/PageHeader'
 
 export const PageHeader = ({
-  iconComponents: IconComponent,
+  iconComponent: IconComponent,
   koreanTitle,
   englishSubtitle,
-  metaContent,
-  actionElements,
   textAlign = 'left',
   headerSize = 'large',
   className,
@@ -41,8 +39,25 @@ export const PageHeader = ({
               <IconComponent className="text-neurtal-700 h-5 w-5" />
             </div>
           )}
+          <div>
+            <h1
+              className={cn(
+                'truncate font-semibold text-neutral-900',
+                headerSize === 'large' ? 'text-xl md:text-2xl' : 'text-lg'
+              )}
+            >
+              {koreanTitle}
+            </h1>
+            {englishSubtitle && (
+              <p className="truncate text-[11px] tracking-[.18em] text-neutral-500 uppercase md:text-xs">
+                {englishSubtitle}
+              </p>
+            )}
+          </div>
         </div>
       </div>
+      <div className="pointer-events-none absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-transparent via-neutral-200 to-transparent" />
+      {children}
     </header>
   )
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,4 +1,42 @@
-import type { LucideIcon } from "lucide-react";
-import { cn } from "../utils/cn";
-import type { PropsWithChildren, ReactNode } from "react";
+import { cn } from '../utils/cn'
+import type { PageHeaderProps } from '../types/PageHeader'
 
+export const PageHeader = ({
+  iconComponents: IconComponent,
+  koreanTitle,
+  englishSubtitle,
+  metaContent,
+  actionElements,
+  textAlign = 'left',
+  headerSize = 'large',
+  className,
+  children,
+}: PageHeaderProps) => {
+  return (
+    <header
+      className={cn(
+        'relative rounded-2xl border border-neutral-200 bg-neutral-50/70 shadow-sm',
+        'px-5 md:px-6',
+        headerSize === 'large' ? 'py-5 md:py-6' : 'py-3.5',
+        className
+      )}
+      role="banner"
+    >
+      <div
+        className={cn(
+          'flex flex-col gap-3 md:flex-row md:items-center',
+          textAlign === 'center'
+            ? 'text-center md:justify-center'
+            : 'md:justify-between'
+        )}
+      >
+        <div
+          className={cn(
+            'flex items-center gap-3',
+            textAlign === 'center' && 'md:justify-center'
+          )}
+        ></div>
+      </div>
+    </header>
+  )
+}

--- a/src/pages/RecruitmentManagementPage.tsx
+++ b/src/pages/RecruitmentManagementPage.tsx
@@ -5,9 +5,10 @@ import { Pagination } from '../components/pagination/Pagination'
 import { RecruitmentFilterSection } from '../components/recruitments/filter/RecruitmentFilterSection'
 import type { Recruitment, RecruitmentStatusApi } from '../types/recruitments'
 import { RecruitmentTableSection } from '../components/recruitments/table/RecruitmentTableSection'
-import { Inbox } from 'lucide-react'
+import { Inbox, Megaphone } from 'lucide-react'
 import { RecruitmentModal } from '../components/recruitments/modal/RecruitmentModal'
 // import { useAdminRecruitmentsQuery } from '../hooks/recruitments/useRecruitmentsQuery'
+import { PageHeader } from '../components/PageHeader'
 
 const PAGE_SIZE = 10
 // 여기서부터
@@ -117,7 +118,11 @@ const RecruitmentManagementPage = () => {
 
   return (
     <div className="space-y-4 p-6">
-      <h1 className="text-lg font-semibold text-neutral-800">공고 관리</h1>
+      <PageHeader
+        iconComponent={Megaphone}
+        koreanTitle="공고 관리"
+        englishSubtitle="RECRUITMENT MANAGEMENT"
+      />
 
       <RecruitmentFilterSection
         searchText={searchText}

--- a/src/types/PageHeader.ts
+++ b/src/types/PageHeader.ts
@@ -1,0 +1,13 @@
+import type { LucideIcon } from 'lucide-react'
+import type { PropsWithChildren, ReactNode } from 'react'
+
+export interface PagerHeaderProps extends PropsWithChildren {
+  iconComponents?: LucideIcon
+  koreanTitle: string
+  englishSubtitle: string
+  metaContent?: ReactNode
+  actionElements?: ReactNode
+  textAlign?: 'left' | 'center'
+  headerSize?: 'medium' | 'large'
+  className?: string
+}

--- a/src/types/PageHeader.ts
+++ b/src/types/PageHeader.ts
@@ -2,10 +2,9 @@ import type { LucideIcon } from 'lucide-react'
 import type { PropsWithChildren, ReactNode } from 'react'
 
 export interface PageHeaderProps extends PropsWithChildren {
-  iconComponents?: LucideIcon
+  iconComponent?: LucideIcon
   koreanTitle: string
   englishSubtitle: string
-  metaContent?: ReactNode
   actionElements?: ReactNode
   textAlign?: 'left' | 'center'
   headerSize?: 'medium' | 'large'

--- a/src/types/PageHeader.ts
+++ b/src/types/PageHeader.ts
@@ -1,7 +1,7 @@
 import type { LucideIcon } from 'lucide-react'
 import type { PropsWithChildren, ReactNode } from 'react'
 
-export interface PagerHeaderProps extends PropsWithChildren {
+export interface PageHeaderProps extends PropsWithChildren {
   iconComponents?: LucideIcon
   koreanTitle: string
   englishSubtitle: string


### PR DESCRIPTION
## 작업 내용
- 페이지에 들어갈 공용헤더를 제작하였습니닷!
- UI는 너무 허접합니다 ㅠㅠ

- 사용방법
```tsx
import { PageHeader } from '../components/PageHeader'
import { Megaphone } from 'lucide-react'      // 각자 사용할 아이콘 임포트 해주세요!

헤더 자리에 아래 코드만 추가해주시면 끄읏.
      <PageHeader
        iconComponent={Megaphone}
        koreanTitle="공고 관리"
        englishSubtitle="RECRUITMENT MANAGEMENT"
      />
```
---

## 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 통과
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요. ex) Closes #123 -->

Closes #131 

---

## 스크린샷 (선택)
1. 빌드완료
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/cfd97c09-3c98-4e86-a64a-ad0bde924273" />

2. 예제이미지
<img width="1905" height="991" alt="image" src="https://github.com/user-attachments/assets/991b7ee6-89dc-4dce-83d2-30a857a07fc7" />