### PR TITLE
[FIX] 모달 헤더 프롭스 추가, 스타일 변경

### DIFF
--- a/src/components/application/modal/ApplicationPageModal.tsx
+++ b/src/components/application/modal/ApplicationPageModal.tsx
@@ -3,6 +3,7 @@ import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import Modal from '../../modal/Modal'
 import { ModalHeader } from '../../modal/ModalHeader'
 import { ApplicationModalOutlet } from './ApplicationModalOutlet'
+import { ClipboardList } from 'lucide-react'
 
 interface ApplicationPageModalProps {
   open: boolean
@@ -19,8 +20,13 @@ export const ApplicationPageModal = ({
 
   return (
     <Modal isOn={open} onBackgroundClick={onClose}>
-      <ModalHeader title="지원 내역 상세" onClose={onClose} />
-        <ApplicationModalOutlet detail={detail} />
+      <ModalHeader
+        title="지원 내역 상세"
+        onClose={onClose}
+        subtitle="APPLICATION DETAIL"
+        iconComponent={ClipboardList}
+      />
+      <ApplicationModalOutlet detail={detail} />
       <CloseModalFooter onClose={onClose} />
     </Modal>
   )

--- a/src/components/application/modal/ApplicationPageModal.tsx
+++ b/src/components/application/modal/ApplicationPageModal.tsx
@@ -23,7 +23,7 @@ export const ApplicationPageModal = ({
       <ModalHeader
         title="지원 내역 상세"
         onClose={onClose}
-        subtitle="APPLICATION DETAIL"
+        subtitle="APPLICATION detail"
         iconComponent={ClipboardList}
       />
       <ApplicationModalOutlet detail={detail} />

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -20,7 +20,7 @@ export const ModalHeader = ({
 }: ModalHeaderProps) => (
   <div
     className={cn(
-      'mb-6 flex items-start justify-between rounded-t-xl bg-gradient-to-r from-white via-neutral-50 to-white p-4 shadow-sm',
+      'mb-6 flex items-center justify-between',
       align === 'center' && 'flex-col items-center text-center',
       className
     )}
@@ -32,12 +32,12 @@ export const ModalHeader = ({
       )}
     >
       {IconComponent && (
-        <div className="grid h-9 w-9 place-items-center rounded-lg border border-neutral-300 bg-white shadow-sm">
-          <IconComponent className="h-4 w-4 text-neutral-700" />
+        <div className="grid h-14 w-14 place-items-center rounded-lg border border-neutral-300 bg-white shadow-sm">
+          <IconComponent className="h-10 w-10 text-neutral-700" />
         </div>
       )}
       <div>
-        <h2 className="text-neutral text-lg font-semibold">{title}</h2>
+        <h2 className="text-neutral text-xl font-semibold">{title}</h2>
         {subtitle && (
           <p className="text-[11px] tracking-[.15em] text-neutral-500 uppercase">
             {subtitle}

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -1,6 +1,5 @@
-import { X } from 'lucide-react'
+import { X, type LucideIcon } from 'lucide-react'
 import { cn } from '../../utils/cn'
-import type { LucideIcon } from 'lucide-react'
 
 interface ModalHeaderProps {
   title: string
@@ -13,13 +12,39 @@ interface ModalHeaderProps {
 
 export const ModalHeader = ({
   title,
+  subtitle,
+  iconComponent: IconComponent,
   onClose,
-}: {
-  title: string
-  onClose: () => void
-}) => (
-  <div className="mb-6 flex items-center justify-between">
-    <h2 className="text-neutral text-lg font-semibold">{title}</h2>
+  align = 'left',
+  className,
+}: ModalHeaderProps) => (
+  <div
+    className={cn(
+      'mb-6 flex items-center justify-between',
+      align === 'center' && 'flex-col items-center text-center',
+      className
+    )}
+  >
+    <div
+      className={cn(
+        'flex items-center gap-3',
+        align === 'center' && 'justify-center'
+      )}
+    >
+      {IconComponent && (
+        <div className="grid h-9 w-9 place-items-center rounded-lg border border-neutral-300 bg-white shadow-sm">
+          <IconComponent className="h-4 w-4 text-neutral-700" />
+        </div>
+      )}
+      <div>
+        <h2 className="text-neutral text-lg font-semibold">{title}</h2>
+        {subtitle && (
+          <p className="text-[11px] tracking-[.15em] text-neutral-500 uppercase">
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
     <button
       onClick={onClose}
       className="rounded-md p-1 text-neutral-500 transition hover:bg-neutral-100"

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -1,4 +1,15 @@
 import { X } from 'lucide-react'
+import { cn } from '../../utils/cn'
+import type { LucideIcon } from 'lucide-react'
+
+interface ModalHeaderProps {
+  title: string
+  subtitle?: string
+  iconComponent?: LucideIcon
+  onClose: () => void
+  align?: 'left' | 'center'
+  className?: string
+}
 
 export const ModalHeader = ({
   title,

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -20,7 +20,7 @@ export const ModalHeader = ({
 }: ModalHeaderProps) => (
   <div
     className={cn(
-      'mb-6 flex items-center justify-between',
+      'mb-6 flex items-start justify-between rounded-t-xl bg-gradient-to-r from-white via-neutral-50 to-white p-4 shadow-sm',
       align === 'center' && 'flex-col items-center text-center',
       className
     )}

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -1,13 +1,10 @@
 import { X, type LucideIcon } from 'lucide-react'
-import { cn } from '../../utils/cn'
 
 interface ModalHeaderProps {
   title: string
   subtitle?: string
   iconComponent?: LucideIcon
   onClose: () => void
-  align?: 'left' | 'center'
-  className?: string
 }
 
 export const ModalHeader = ({
@@ -15,22 +12,9 @@ export const ModalHeader = ({
   subtitle,
   iconComponent: IconComponent,
   onClose,
-  align = 'left',
-  className,
 }: ModalHeaderProps) => (
-  <div
-    className={cn(
-      'mb-6 flex items-center justify-between',
-      align === 'center' && 'flex-col items-center text-center',
-      className
-    )}
-  >
-    <div
-      className={cn(
-        'flex items-center gap-3',
-        align === 'center' && 'justify-center'
-      )}
-    >
+  <div className="mb-6 flex items-center justify-between">
+    <div className="flex items-center gap-3">
       {IconComponent && (
         <div className="grid h-14 w-14 place-items-center rounded-lg border border-neutral-300 bg-white shadow-sm">
           <IconComponent className="h-10 w-10 text-neutral-700" />

--- a/src/components/recruitments/modal/RecruitmentModal.tsx
+++ b/src/components/recruitments/modal/RecruitmentModal.tsx
@@ -3,6 +3,7 @@ import type { RecruitmentDetail } from '../../../types/recruitments'
 import { ModalHeader } from '../../modal/ModalHeader'
 import { RecruitmentModalOutlet } from './RecruitmentModalOutlet'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
+import { Megaphone } from 'lucide-react'
 
 interface RecruitmentModalProps {
   open: boolean
@@ -19,7 +20,12 @@ export const RecruitmentModal = ({
 }: RecruitmentModalProps) => {
   return (
     <Modal isOn={open} onBackgroundClick={onClose}>
-      <ModalHeader title="스터디 구인 공고 상세" onClose={onClose} />
+      <ModalHeader
+        title="스터디 구인 공고 상세"
+        onClose={onClose}
+        subtitle="RECRUITMENT DETAIL"
+        iconComponent={Megaphone}
+      />
       <RecruitmentModalOutlet detail={detail} />
       <CloseModalFooter onClose={onClose} showDelete onDelete={onDelete} />
     </Modal>

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -3,6 +3,7 @@ import type { ReviewDetail } from '../../types/reviews/types'
 import { ModalHeader } from '../modal/ModalHeader'
 import { ReviewModalOutlet } from '../reviews/ReviewModalOutlet'
 import { CloseModalFooter } from '../modal/CloseModalFooter'
+import { Star } from 'lucide-react'
 
 interface ReviewModalProps {
   open: boolean
@@ -13,7 +14,12 @@ interface ReviewModalProps {
 export const ReviewModal = ({ open, onClose, review }: ReviewModalProps) => {
   return (
     <Modal isOn={open} onBackgroundClick={onClose}>
-      <ModalHeader title="리뷰 상세보기" onClose={onClose} />
+      <ModalHeader
+        title="리뷰 상세보기"
+        subtitle="DETAIL REVIEW"
+        iconComponent={Star}
+        onClose={onClose}
+      />
       <ReviewModalOutlet review={review} />
       <CloseModalFooter onClose={onClose} />
     </Modal>

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -16,7 +16,7 @@ export const ReviewModal = ({ open, onClose, review }: ReviewModalProps) => {
     <Modal isOn={open} onBackgroundClick={onClose}>
       <ModalHeader
         title="리뷰 상세보기"
-        subtitle="DETAIL REVIEW"
+        subtitle="REVIEW DETAIL"
         iconComponent={Star}
         onClose={onClose}
       />


### PR DESCRIPTION
## 작업 내용
- 모달 헤더 부분이 밋밋한 것 같아서 프롭스만 추가해서 스타일을 변경할 수 있도록 수정하였습니다.
- uppercase를 사용함으로써, 소문자를 입력하더라도 대문자로 보일 수 있게 예외 처리하였습니다!

사용 방법
```tsx
import { ClipboardList } from 'lucide-react' // 원하는 아이콘 임포트

   <ModalHeader
        title="지원 내역 상세"
        onClose={onClose}
        subtitle="APPLICATION detail"    // 추가
        iconComponent={ClipboardList}    // 추가
    >
```
세 부분만 추가해주시면 됩니다!
---

## 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 통과
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요. ex) Closes #123 -->

Closes #152

---

## 스크린샷 (선택)
1. 빌드완료
<img width="1920" height="971" alt="image" src="https://github.com/user-attachments/assets/9f566448-4471-40a3-b101-d442d2177beb" />
2.적용 전
<img width="843" height="692" alt="image" src="https://github.com/user-attachments/assets/30315086-e0e0-469c-9763-1fa280272afc" />
3. 적용 후
<img width="829" height="801" alt="image" src="https://github.com/user-attachments/assets/1616e2fe-ad29-43ab-8089-c175530b3057" />
