### PR TITLE
[FEAT] BODY_SCROLL_LOCK 훅 제작

### DIFF
--- a/src/components/application/modal/ApplicationPageModal.tsx
+++ b/src/components/application/modal/ApplicationPageModal.tsx
@@ -1,3 +1,4 @@
+import { useBodyScrollLock } from '../../../hooks/useBodyScrollLock'
 import type { ApplicationDetail } from '../../../types/applications'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import Modal from '../../modal/Modal'
@@ -16,6 +17,7 @@ export const ApplicationPageModal = ({
   onClose,
   detail,
 }: ApplicationPageModalProps) => {
+  useBodyScrollLock(open)
   if (!detail) return null
 
   return (

--- a/src/components/recruitments/modal/RecruitmentModal.tsx
+++ b/src/components/recruitments/modal/RecruitmentModal.tsx
@@ -5,7 +5,6 @@ import { RecruitmentModalOutlet } from './RecruitmentModalOutlet'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import { Megaphone } from 'lucide-react'
 import { useBodyScrollLock } from '../../../hooks/useBodyScrollLock'
-import { Megaphone } from 'lucide-react'
 
 interface RecruitmentModalProps {
   open: boolean

--- a/src/components/recruitments/modal/RecruitmentModal.tsx
+++ b/src/components/recruitments/modal/RecruitmentModal.tsx
@@ -4,7 +4,6 @@ import { ModalHeader } from '../../modal/ModalHeader'
 import { RecruitmentModalOutlet } from './RecruitmentModalOutlet'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import { Megaphone } from 'lucide-react'
-import { useBodyScrollLock } from '../../../hooks/useBodyScrollLock'
 
 interface RecruitmentModalProps {
   open: boolean

--- a/src/components/recruitments/modal/RecruitmentModal.tsx
+++ b/src/components/recruitments/modal/RecruitmentModal.tsx
@@ -4,6 +4,7 @@ import { ModalHeader } from '../../modal/ModalHeader'
 import { RecruitmentModalOutlet } from './RecruitmentModalOutlet'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import { Megaphone } from 'lucide-react'
+import { useBodyScrollLock } from '../../../hooks/useBodyScrollLock'
 
 interface RecruitmentModalProps {
   open: boolean

--- a/src/components/recruitments/modal/RecruitmentModal.tsx
+++ b/src/components/recruitments/modal/RecruitmentModal.tsx
@@ -4,6 +4,7 @@ import { ModalHeader } from '../../modal/ModalHeader'
 import { RecruitmentModalOutlet } from './RecruitmentModalOutlet'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import { Megaphone } from 'lucide-react'
+import { useBodyScrollLock } from '../../../hooks/useBodyScrollLock'
 
 interface RecruitmentModalProps {
   open: boolean
@@ -18,6 +19,7 @@ export const RecruitmentModal = ({
   onDelete,
   detail,
 }: RecruitmentModalProps) => {
+  useBodyScrollLock(open)
   return (
     <Modal isOn={open} onBackgroundClick={onClose}>
       <ModalHeader

--- a/src/components/recruitments/modal/RecruitmentModal.tsx
+++ b/src/components/recruitments/modal/RecruitmentModal.tsx
@@ -5,6 +5,7 @@ import { RecruitmentModalOutlet } from './RecruitmentModalOutlet'
 import { CloseModalFooter } from '../../modal/CloseModalFooter'
 import { Megaphone } from 'lucide-react'
 import { useBodyScrollLock } from '../../../hooks/useBodyScrollLock'
+import { Megaphone } from 'lucide-react'
 
 interface RecruitmentModalProps {
   open: boolean

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -4,6 +4,7 @@ import { ModalHeader } from '../modal/ModalHeader'
 import { ReviewModalOutlet } from '../reviews/ReviewModalOutlet'
 import { CloseModalFooter } from '../modal/CloseModalFooter'
 import { Star } from 'lucide-react'
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock'
 
 interface ReviewModalProps {
   open: boolean

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -18,7 +18,7 @@ export const ReviewModal = ({ open, onClose, review }: ReviewModalProps) => {
     <Modal isOn={open} onBackgroundClick={onClose}>
       <ModalHeader
         title="리뷰 상세보기"
-        subtitle="DETAIL REVIEW"
+        subtitle="REVIEW DETAIL"
         iconComponent={Star}
         onClose={onClose}
       />

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -18,7 +18,7 @@ export const ReviewModal = ({ open, onClose, review }: ReviewModalProps) => {
     <Modal isOn={open} onBackgroundClick={onClose}>
       <ModalHeader
         title="리뷰 상세보기"
-        subtitle="REVIEW DETAIL"
+        subtitle="DETAIL REVIEW"
         iconComponent={Star}
         onClose={onClose}
       />

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -4,7 +4,6 @@ import { ModalHeader } from '../modal/ModalHeader'
 import { ReviewModalOutlet } from '../reviews/ReviewModalOutlet'
 import { CloseModalFooter } from '../modal/CloseModalFooter'
 import { Star } from 'lucide-react'
-import { useBodyScrollLock } from '../../hooks/useBodyScrollLock'
 
 interface ReviewModalProps {
   open: boolean

--- a/src/components/reviews/ReviewModal.tsx
+++ b/src/components/reviews/ReviewModal.tsx
@@ -4,6 +4,7 @@ import { ModalHeader } from '../modal/ModalHeader'
 import { ReviewModalOutlet } from '../reviews/ReviewModalOutlet'
 import { CloseModalFooter } from '../modal/CloseModalFooter'
 import { Star } from 'lucide-react'
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock'
 
 interface ReviewModalProps {
   open: boolean
@@ -12,6 +13,7 @@ interface ReviewModalProps {
 }
 
 export const ReviewModal = ({ open, onClose, review }: ReviewModalProps) => {
+  useBodyScrollLock(open)
   return (
     <Modal isOn={open} onBackgroundClick={onClose}>
       <ModalHeader

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+
+export const useBodyScrollLock = (isScrollLocked: boolean): void => {
+  useEffect(() => {
+    if (!isScrollLocked) return
+
+    const previousBodyOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = previousBodyOverflow
+    }
+  }, [isScrollLocked])
+}


### PR DESCRIPTION
## 작업 내용
- 어제 피드백주셨던 모달 스크롤하는데, 바디도 같이 스크롤되는 부분을 보완하고자 훅을 제작하였습니다.
- 사용방법
```tsx
import { useBodyScrollLock } from '경로에 맞춰서 수정'

export const ReviewModal = ({ open, onClose, review }: ReviewModalProps) => {
  useBodyScrollLock(open)              // 이거 한줄만 추가해주시면 끝납니당.
  return (
    <Modal isOn={open} onBackgroundClick={onClose}>
      <ModalHeader title="리뷰 상세보기" onClose={onClose} />
      <ReviewModalOutlet review={review} />
      <CloseModalFooter onClose={onClose} />
    </Modal>
  )
}
```
---

## 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 통과
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈
Closes #154 

---

## 스크린샷 (선택)
1. 빌드완료
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/ddf16a37-747f-4789-a56b-bedb86fae08b" />
2. 훅 적용하기 전
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/70d840ed-a66b-4dc0-8df3-5b4556bd13aa" />
3. 훅 적용한 후
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/6ed6e36f-5b8a-426e-b0a6-8765b2e600d1" />
